### PR TITLE
Harden lead-time pipeline and expand test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ key.txt
 outlier_reports_*/
 lead_times_*/
 poetry.lock
+*.md
 
 # Created by https://www.toptal.com/developers/gitignore/api/dotenv,python,jupyternotebooks,visualstudiocode,pycharm
 # Edit at https://www.toptal.com/developers/gitignore?templates=dotenv,python,jupyternotebooks,visualstudiocode,pycharm

--- a/design-notes.md
+++ b/design-notes.md
@@ -1,0 +1,128 @@
+# Design Notes
+
+## Idempotent, Incremental, and Resumable Database Builds
+
+### Overview
+
+The database build is designed so that every run is safe to abort and
+re-run. The database can be built up incrementally across multiple
+partial runs without corrupting data or creating duplicate rows. Each
+committed batch of work is immediately durable: a run that is aborted
+picks up exactly where it left off on the next invocation.
+
+This property is valuable because the data collection involves many
+slow, rate-limited API calls. Progress must not be lost on interruption.
+
+---
+
+### Mechanism 1: `INSERT OR IGNORE` + `UNIQUE` constraints
+
+Every write to a permanent table uses `INSERT OR IGNORE`, backed by a
+`UNIQUE` constraint on the record's natural key:
+
+| Table | Natural unique key |
+|---|---|
+| `projects` | `project_internal_id` |
+| `releases` | `release_internal_id` |
+| `stories` | `(story_key, release_internal_id)` |
+| `pull_requests` | `(pr_owner, pr_repository, pr_number)` |
+| `stories_pull_requests` | `(story_id, pr_id)` |
+
+`INSERT OR IGNORE` silently skips any row whose natural key already
+exists. Re-running any `save_*` method with the same API data is always
+safe — rows are written at most once.
+
+---
+
+### Mechanism 2: "Not-yet-done" sentinel queries
+
+Each step in `main.py` queries the database for *only the work that
+has not yet been completed*. This is what makes the build incremental
+and resumable.
+
+**`retrieve_releases_without_stories()`**
+Uses a `LEFT JOIN` on the `stories` table. A release is returned only
+if it has no story row yet.
+
+**`retrieve_stories_without_pull_requests()`**
+Uses a `LEFT OUTER JOIN` against the `stories_pull_request_counts`
+table. A story is included in results only if it has no row in that
+table — meaning its PR lookup has never been attempted. Crucially, when
+`save_story_pull_requests()` runs it writes a row for every story,
+including ones where `pr_count = 0` (the story has no linked PRs).
+This correctly records "we looked and found nothing", so the API is
+never called again for that story on a subsequent run.
+
+**`retrieve_pull_requests_without_details()`**
+Uses `pr_title IS NULL` as the sentinel. A pull request is inserted
+into the `pull_requests` table when its identifier is first seen
+(owner, repository, number). Its detail columns (`pr_title`, dates,
+commit counts) are all `NULL` at that point. After
+`save_pull_request_details()` runs, `pr_title` is populated and the
+row is excluded from future queries.
+
+---
+
+### Mechanism 3: Staged two-phase writes
+
+`save_releases`, `save_stories`, and `save_story_pull_requests` use a
+temporary staging table to keep each write operation atomic:
+
+```
+1. CREATE TABLE IF NOT EXISTS stage_*  (temp table)
+2. INSERT  raw API data → stage_*
+3. INSERT OR IGNORE  permanent table ← SELECT … FROM stage_*
+                                       (resolves foreign-key IDs)
+4. DROP TABLE IF EXISTS stage_*
+5. conn.commit()
+```
+
+The staging table decouples the API data shape (which uses natural
+string keys such as `project_key` and `release_internal_id`) from the
+permanent table shape (which uses integer `id` foreign keys). Step 3
+performs the join and key resolution in a single SQL statement. If
+anything fails before step 5, the transaction is rolled back and the
+permanent table is unchanged.
+
+---
+
+### Mechanism 4: Per-batch commits with limits
+
+Steps 5 and 6 in `main.py` use `while True` loops that retrieve and
+process 100 items per iteration, committing after each batch:
+
+```python
+while True:
+    items = db.retrieve_items_without_details(limit=100)
+    if not items:
+        break
+    details = api_client.get_details(items)
+    db.save_details(details)   # commits inside
+```
+
+Each committed batch is immediately durable. A crash after any commit
+leaves all prior batches intact in the database; the next run resumes
+from the first uncommitted item.
+
+---
+
+### API error handling and the build loop
+
+`api_get()` in `api_client.py` applies three error checks after every
+HTTP call, in order:
+
+1. `raise_if_auth_error` — raises `AuthError` on 401/403
+2. `raise_if_rate_limit_error` — raises `RateLimitError` on 429,
+   logging when the rate limit resets
+3. `raise_if_api_error` (structural calls only) — raises `ApiError`
+   on any other 4xx/5xx
+
+`AuthError`, `RateLimitError`, and `ApiError` are all caught at the top
+level in `main.py`, which logs a clear message and exits. Because every
+batch has already been committed before the failing API call is made,
+no committed data is lost.
+
+Per-item failures (a single PR or Jira story that returns a non-200)
+are logged as warnings and skipped; they do not stop the run.
+
+---

--- a/dora_lead_time/api_client.py
+++ b/dora_lead_time/api_client.py
@@ -169,7 +169,7 @@ def api_get(
         auth: Optional ``(username, password)`` tuple for HTTP Basic Auth.
         params: Optional query-string parameters to append to the URL.
         timeout: Request timeout in seconds. Defaults to 30.
-        raise_on_error: If ``True``, raise ``ApiError`` for any non-2xx
+        raise_on_error: If ``True``, raise ``ApiError`` for any 4xx/5xx
             response not already handled by ``raise_if_auth_error`` or
             ``raise_if_rate_limit_error``. If ``False``, return the response
             regardless of status code.

--- a/dora_lead_time/api_client.py
+++ b/dora_lead_time/api_client.py
@@ -1,0 +1,193 @@
+"""API client utilities: custom exceptions, error-checking helpers, and HTTP GET."""
+
+import enum
+import logging
+from datetime import datetime, timezone
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class ApiSource(enum.Enum):
+    """Identifies the external API that a request was made against."""
+
+    GITHUB = "GitHub"
+    ATLASSIAN = "Atlassian"
+
+
+class AuthError(Exception):
+    """Raised when an API request fails due to an authentication error.
+
+    Attributes:
+        message: Explanation of which token failed and why.
+    """
+
+
+class RateLimitError(Exception):
+    """Raised when an API request is rejected due to rate limiting.
+
+    Attributes:
+        message: Explanation of the rate limit and when to retry.
+    """
+
+
+class ApiError(Exception):
+    """Raised when a structural API request fails with an unrecoverable error.
+
+    Attributes:
+        message: Explanation of what request failed and the HTTP status code.
+    """
+
+
+def raise_if_auth_error(
+    response: requests.Response, source: ApiSource
+) -> None:
+    """Raise AuthError if the response indicates an authentication failure.
+
+    Args:
+        response: The HTTP response to inspect.
+        source: The API source that returned the response.
+
+    Raises:
+        AuthError: If the response status code is 401 or 403.
+    """
+    if response.status_code in (401, 403):
+        raise AuthError(
+            f"Authentication failed for {source.value} "
+            f"(HTTP {response.status_code}). "
+            "Please check that your API token is valid and has not expired."
+        )
+
+
+def raise_if_rate_limit_error(
+    response: requests.Response, source: ApiSource
+) -> None:
+    """Raise RateLimitError if the response indicates a rate-limit failure.
+
+    Reads the ``Retry-After`` header (seconds to wait, used by Atlassian and
+    other generic APIs) or the ``x-ratelimit-reset`` header (Unix timestamp,
+    used by GitHub) to determine and log when it is safe to retry.
+
+    Args:
+        response: The HTTP response to inspect.
+        source: The API source that returned the response.
+
+    Raises:
+        RateLimitError: If the response status code is 429.
+    """
+    if response.status_code != 429:
+        return
+
+    retry_message = "Retry time unknown."
+
+    retry_after = response.headers.get("Retry-After")
+    ratelimit_reset = response.headers.get("x-ratelimit-reset")
+
+    if retry_after is not None:
+        try:
+            retry_seconds = int(retry_after)
+            retry_at = datetime.now(tz=timezone.utc).timestamp() + retry_seconds
+            retry_dt = datetime.fromtimestamp(retry_at, tz=timezone.utc)
+            retry_message = (
+                f"Retry after {retry_seconds} seconds "
+                f"(at {retry_dt.strftime('%Y-%m-%d %H:%M:%S UTC')})."
+            )
+        except ValueError:
+            retry_message = f"Retry after: {retry_after}."
+    elif ratelimit_reset is not None:
+        try:
+            reset_dt = datetime.fromtimestamp(
+                int(ratelimit_reset), tz=timezone.utc
+            )
+            retry_message = (
+                f"Rate limit resets at "
+                f"{reset_dt.strftime('%Y-%m-%d %H:%M:%S UTC')}."
+            )
+        except ValueError:
+            retry_message = f"Rate limit reset: {ratelimit_reset}."
+
+    logger.error(
+        "Rate limit exceeded for %s. %s", source.value, retry_message
+    )
+    raise RateLimitError(
+        f"Rate limit exceeded for {source.value}. {retry_message}"
+    )
+
+
+def raise_if_api_error(
+    response: requests.Response, source: ApiSource
+) -> None:
+    """Raise ApiError for any unrecoverable non-2xx response.
+
+    Intended for structural, list-based requests where a failure means the
+    entire operation cannot proceed. Call this after ``raise_if_auth_error``
+    and ``raise_if_rate_limit_error`` have already been invoked so that 401,
+    403, and 429 responses are handled by their dedicated helpers.
+
+    Args:
+        response: The HTTP response to inspect.
+        source: The API source that returned the response.
+
+    Raises:
+        ApiError: If the response status code is 400 or higher.
+    """
+    if response.status_code >= 400:
+        raise ApiError(
+            f"{source.value} API request failed "
+            f"(HTTP {response.status_code})."
+        )
+
+
+def api_get(
+    url: str,
+    source: ApiSource,
+    headers: dict[str, str],
+    *,
+    auth: tuple[str, str] | None = None,
+    params: dict | None = None,
+    timeout: int = 30,
+    raise_on_error: bool = True,
+) -> requests.Response:
+    """Make a GET request with standard error checking.
+
+    Always raises ``AuthError`` on 401/403 and ``RateLimitError`` on 429.
+
+    When *raise_on_error* is ``True`` (the default), also raises ``ApiError``
+    for any remaining non-2xx response — use this for structural or
+    list-based requests where a failure means the entire operation cannot
+    proceed.
+
+    When *raise_on_error* is ``False``, returns the response as-is so the
+    caller can inspect ``status_code``, log a meaningful message, and skip
+    the individual item.
+
+    Args:
+        url: The URL to GET.
+        source: The API source, used in error messages.
+        headers: HTTP headers to include in the request.
+        auth: Optional ``(username, password)`` tuple for HTTP Basic Auth.
+        params: Optional query-string parameters to append to the URL.
+        timeout: Request timeout in seconds. Defaults to 30.
+        raise_on_error: If ``True``, raise ``ApiError`` for any non-2xx
+            response not already handled by ``raise_if_auth_error`` or
+            ``raise_if_rate_limit_error``. If ``False``, return the response
+            regardless of status code.
+
+    Returns:
+        The HTTP response.
+
+    Raises:
+        AuthError: If the response status is 401 or 403.
+        RateLimitError: If the response status is 429.
+        ApiError: If the response status is >= 400 and *raise_on_error*
+            is ``True``.
+    """
+    response = requests.get(
+        url, headers=headers, auth=auth, params=params, timeout=timeout
+    )
+    raise_if_auth_error(response, source)
+    raise_if_rate_limit_error(response, source)
+    if raise_on_error:
+        raise_if_api_error(response, source)
+    return response

--- a/dora_lead_time/api_client.py
+++ b/dora_lead_time/api_client.py
@@ -154,7 +154,7 @@ def api_get(
     Always raises ``AuthError`` on 401/403 and ``RateLimitError`` on 429.
 
     When *raise_on_error* is ``True`` (the default), also raises ``ApiError``
-    for any remaining non-2xx response — use this for structural or
+    for any remaining 4xx/5xx response — use this for structural or
     list-based requests where a failure means the entire operation cannot
     proceed.
 

--- a/dora_lead_time/api_client.py
+++ b/dora_lead_time/api_client.py
@@ -118,7 +118,7 @@ def raise_if_rate_limit_error(
 def raise_if_api_error(
     response: requests.Response, source: ApiSource
 ) -> None:
-    """Raise ApiError for any unrecoverable non-2xx response.
+    """Raise ApiError for any unrecoverable 4xx/5xx response.
 
     Intended for structural, list-based requests where a failure means the
     entire operation cannot proceed. Call this after ``raise_if_auth_error``

--- a/dora_lead_time/atlassian_requests.py
+++ b/dora_lead_time/atlassian_requests.py
@@ -5,10 +5,9 @@ import os
 import textwrap
 from datetime import date, datetime
 from typing import Dict, List
-
-import requests
 from dotenv import load_dotenv
 
+from dora_lead_time.api_client import ApiSource, api_get
 from dora_lead_time.models import (
     Project,
     Release,
@@ -75,13 +74,10 @@ class AtlassianRequests:
         }
         auth = (self.email, self.token)
         projects_url = f"https://{self.jira_instance}/rest/api/3/project"
-        response = requests.get(
-            projects_url,
-            headers=headers,
-            auth=auth,
-            timeout=self.request_timeout
+        response = api_get(
+            projects_url, ApiSource.ATLASSIAN, headers,
+            auth=auth, timeout=self.request_timeout,
         )
-        response.raise_for_status()
 
         all_projects = response.json()
         projects = [
@@ -120,13 +116,10 @@ class AtlassianRequests:
         }
         auth = (self.email, self.token)
         projects_url = f"https://{self.jira_instance}/rest/api/3/project"
-        response = requests.get(
-            projects_url,
-            headers=headers,
-            auth=auth,
-            timeout=self.request_timeout
+        response = api_get(
+            projects_url, ApiSource.ATLASSIAN, headers,
+            auth=auth, timeout=self.request_timeout,
         )
-        response.raise_for_status()
 
         all_projects = response.json()
         project_keys = [
@@ -138,10 +131,17 @@ class AtlassianRequests:
         releases = []
         for project_key in project_keys:
             url = f"{projects_url}/{project_key}/versions"
-            response = requests.get(
-                url, headers=headers, auth=auth, timeout=self.request_timeout
+            response = api_get(
+                url, ApiSource.ATLASSIAN, headers,
+                auth=auth, timeout=self.request_timeout,
+                raise_on_error=False,
             )
             if response.status_code != 200:
+                logger.warning(
+                    "Could not fetch versions for project %s "
+                    "(HTTP %s); skipping",
+                    project_key, response.status_code
+                )
                 continue
 
             versions = response.json()
@@ -226,14 +226,10 @@ class AtlassianRequests:
             }
 
             logger.info("Fetching stories batch starting at %s", start_at)
-            response = requests.get(
-                url,
-                headers=headers,
-                auth=auth,
-                params=params,
-                timeout=self.request_timeout,
+            response = api_get(
+                url, ApiSource.ATLASSIAN, headers,
+                auth=auth, params=params, timeout=self.request_timeout,
             )
-            response.raise_for_status()
 
             data = response.json()
             is_last = data.get("isLast", False)
@@ -338,11 +334,10 @@ class AtlassianRequests:
             issue_url = (
                 f"https://{self.jira_instance}/rest/api/3/issue/{story}?fields=id"
             )
-            issue_response = requests.get(
-                issue_url,
-                headers=headers,
-                auth=auth,
-                timeout=self.request_timeout
+            issue_response = api_get(
+                issue_url, ApiSource.ATLASSIAN, headers,
+                auth=auth, timeout=self.request_timeout,
+                raise_on_error=False,
             )
 
             if issue_response.status_code != 200:
@@ -365,11 +360,10 @@ class AtlassianRequests:
                 f"&applicationType=GitHub"
                 f"&dataType=pullrequest"
             )
-            dev_response = requests.get(
-                dev_url,
-                headers=headers,
-                auth=auth,
-                timeout=self.request_timeout
+            dev_response = api_get(
+                dev_url, ApiSource.ATLASSIAN, headers,
+                auth=auth, timeout=self.request_timeout,
+                raise_on_error=False,
             )
 
             if dev_response.status_code != 200:

--- a/dora_lead_time/database_processor.py
+++ b/dora_lead_time/database_processor.py
@@ -14,6 +14,10 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+class DatabaseOperationError(Exception):
+    """Raised when a database read or write operation fails unrecoverably."""
+
+
 class DatabaseProcessor:
     """Database operations to create releases database."""
 
@@ -126,6 +130,11 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not retrieve projects from the database"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -180,6 +189,9 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError("Could not create schema") from e
         finally:
             if conn:
                 conn.close()
@@ -226,6 +238,9 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError("Could not save projects") from e
         finally:
             if conn:
                 conn.close()
@@ -272,6 +287,11 @@ class DatabaseProcessor:
 
         except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
             logger.error("Database error while updating project types: %s", e)
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not update project types"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -299,6 +319,12 @@ class DatabaseProcessor:
 
             conn = self._get_connection()
             cursor = conn.cursor()
+
+            cursor.execute(
+                """
+                DROP TABLE IF EXISTS stage_releases
+                """
+            )
 
             cursor.execute(
                 """
@@ -373,6 +399,9 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError("Could not save releases") from e
         finally:
             if conn:
                 conn.close()
@@ -421,6 +450,11 @@ class DatabaseProcessor:
                 e
             )
             release_ids = []
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not get releases without stories"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -447,6 +481,12 @@ class DatabaseProcessor:
 
             conn = self._get_connection()
             cursor = conn.cursor()
+
+            cursor.execute(
+                """
+                DROP TABLE IF EXISTS stage_stories
+                """
+            )
 
             cursor.execute(
                 """
@@ -523,6 +563,9 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError("Could not save stories") from e
         finally:
             if conn:
                 conn.close()
@@ -574,6 +617,11 @@ class DatabaseProcessor:
                 e
             )
             story_keys = []
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not load stories without pull requests"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -621,6 +669,12 @@ class DatabaseProcessor:
 
             conn = self._get_connection()
             cursor = conn.cursor()
+
+            cursor.execute(
+                """
+                DROP TABLE IF EXISTS stage_stories_pull_requests
+                """
+            )
 
             cursor.execute(
                 """
@@ -725,6 +779,11 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not save stories to PR URL mapping"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -785,6 +844,11 @@ class DatabaseProcessor:
                 e
             )
             pull_requests = []
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not load PRs from the database"
+            ) from e
         finally:
             if conn:
                 # Close the connection
@@ -855,6 +919,11 @@ class DatabaseProcessor:
                 """,
                 e
             )
+            if conn:
+                conn.rollback()
+            raise DatabaseOperationError(
+                "Could not update PR details"
+            ) from e
         finally:
             if conn:
                 conn.close()
@@ -931,6 +1000,8 @@ class DatabaseProcessor:
 
         except (sqlite3.OperationalError, sqlite3.DatabaseError) as e:
             logger.error("Failed to retrieve summary data: %s", e)
+            if conn:
+                conn.rollback()
         finally:
             if conn:
                 conn.close()

--- a/dora_lead_time/github_requests.py
+++ b/dora_lead_time/github_requests.py
@@ -4,8 +4,8 @@ import logging
 import os
 from datetime import datetime
 
-import requests
 from dotenv import load_dotenv
+from dora_lead_time.api_client import ApiSource, api_get
 from dora_lead_time.models import PullRequestIdentifier, PullRequest
 
 logging.basicConfig(
@@ -90,13 +90,14 @@ class GitHubRequests:
             headers = {"Authorization": f"token {github_token}"}
 
             api_url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
-            response = requests.get(
-                api_url, headers=headers, timeout=self.request_timeout
+            response = api_get(
+                api_url, ApiSource.GITHUB, headers,
+                timeout=self.request_timeout, raise_on_error=False,
             )
             if response.status_code != 200:
-                logger.error(
-                    "ERROR: Could not fetch PR details for: "
-                    "%s/%s/%s. Status code: %s",
+                logger.warning(
+                    "Could not fetch PR details for %s/%s/%s "
+                    "(HTTP %s); skipping",
                     owner, repo, pr_number, response.status_code
                 )
                 continue
@@ -112,10 +113,16 @@ class GitHubRequests:
 
             # Get commit data
             commits_url = f"{api_url}/commits"
-            commits_response = requests.get(
-                commits_url, headers=headers, timeout=self.request_timeout
+            commits_response = api_get(
+                commits_url, ApiSource.GITHUB, headers,
+                timeout=self.request_timeout, raise_on_error=False,
             )
             if commits_response.status_code != 200:
+                logger.warning(
+                    "Could not fetch commits for PR %s/%s/%s "
+                    "(HTTP %s); commit data will be empty",
+                    owner, repo, pr_number, commits_response.status_code
+                )
                 commits = []
             else:
                 commits = commits_response.json()

--- a/dora_lead_time/lead_time_report.py
+++ b/dora_lead_time/lead_time_report.py
@@ -114,6 +114,11 @@ class LeadTimeReport:
         Calculates the average lead time and number of releases for the
         specified projects within the given date range.
 
+        The average is computed over individual PR lead times, not per
+        release. A release with many PRs contributes proportionally more
+        to the average than a release with few PRs. PRs with a lead time
+        of zero or less (same-day or post-release commits) are excluded.
+
         Args:
             project_keys: List of project keys to include (e.g., ['PR', 'TS']).
             start_date: Start date for the time period (inclusive).
@@ -212,7 +217,7 @@ class LeadTimeReport:
                 project_keys, month_details.start_date, month_details.end_date
             )
             month_names.append(f"{year}-{month}")
-            lead_times.append(int(lead_time.average_lead_time))
+            lead_times.append(round(lead_time.average_lead_time))
             number_of_releases.append(lead_time.number_of_releases)
 
         lead_times_frame = {}
@@ -325,7 +330,7 @@ class LeadTimeReport:
         )
         lead_time_summary = \
             "Lead time for changes is " \
-            f"{int(lead_time.average_lead_time)} days average " \
+            f"{round(lead_time.average_lead_time)} days average " \
             f"over {lead_time.number_of_releases} releases"
 
         # Generate monthly lead time report

--- a/dora_lead_time/main.py
+++ b/dora_lead_time/main.py
@@ -423,8 +423,11 @@ def main():
     if build_database:
         try:
             create_releases_database(config)
-        except (ApiError, AuthError, RateLimitError, DatabaseOperationError) as e:
-            logger.error("API error: %s", e)
+        except (ApiError, AuthError, RateLimitError) as e:
+            logger.error("API error while building database: %s", e)
+            sys.exit(1)
+        except DatabaseOperationError as e:
+            logger.error("Database error while building database: %s", e)
             sys.exit(1)
 
     # Generate reports if flag is set

--- a/dora_lead_time/main.py
+++ b/dora_lead_time/main.py
@@ -1,6 +1,7 @@
 """Main module of the application."""
 
 import os
+import sys
 import logging
 import json
 import argparse
@@ -8,8 +9,9 @@ from datetime import date, datetime
 import pathlib
 from typing import NamedTuple
 from dotenv import load_dotenv
-from dora_lead_time.database_processor import DatabaseProcessor
+from dora_lead_time.database_processor import DatabaseProcessor, DatabaseOperationError
 from dora_lead_time.atlassian_requests import AtlassianRequests
+from dora_lead_time.api_client import ApiError, AuthError, RateLimitError
 from dora_lead_time.github_requests import GitHubRequests
 from dora_lead_time.outlier_reports import OutlierReports
 from dora_lead_time.lead_time_report import LeadTimeReport
@@ -419,7 +421,11 @@ def main():
     # If build flag is set, create the database
     build_database = args.build and config.build_database
     if build_database:
-        create_releases_database(config)
+        try:
+            create_releases_database(config)
+        except (ApiError, AuthError, RateLimitError, DatabaseOperationError) as e:
+            logger.error("API error: %s", e)
+            sys.exit(1)
 
     # Generate reports if flag is set
     if args.reports:
@@ -427,7 +433,11 @@ def main():
 
     # Generate lead time charts if flag is set
     if args.charts:
-        save_lead_time_charts(config)
+        try:
+            save_lead_time_charts(config)
+        except DatabaseOperationError as e:
+            logger.error("Database error generating charts: %s", e)
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/dora_lead_time/outlier_reports/A_projects_without_releases.sql
+++ b/dora_lead_time/outlier_reports/A_projects_without_releases.sql
@@ -1,4 +1,6 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 WITH release_counts AS (
   SELECT
     releases.project_id,

--- a/dora_lead_time/outlier_reports/B_releases_with_open_stories.sql
+++ b/dora_lead_time/outlier_reports/B_releases_with_open_stories.sql
@@ -1,9 +1,12 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 SELECT
   stories.story_key,
   stories.story_title,
   releases.release_title,
   CAST(julianday(date(julianday(stories.story_resolved))) - julianday(releases.release_date) + 1
+  -- +1 makes the count inclusive: if story resolves on the release day itself, days_open = 1.
   AS INTEGER)
     AS days_open,
   releases.release_date,
@@ -14,6 +17,8 @@ FROM
   JOIN releases
     ON stories.release_id = releases.id
 WHERE
+  -- +3: 3-day grace period — stories may legitimately resolve shortly
+  -- after a release during a stabilization window.
   julianday(date(julianday(stories.story_resolved))) > julianday(releases.release_date) + 3
   AND julianday('now') - julianday(releases.release_date) <= 60
 ORDER BY

--- a/dora_lead_time/outlier_reports/C_stories_in_multiple_releases.sql
+++ b/dora_lead_time/outlier_reports/C_stories_in_multiple_releases.sql
@@ -1,4 +1,6 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 WITH duplicate_stories AS (
   SELECT
     stories.story_key

--- a/dora_lead_time/outlier_reports/D_releases_with_open_pull_requests.sql
+++ b/dora_lead_time/outlier_reports/D_releases_with_open_pull_requests.sql
@@ -1,10 +1,14 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 SELECT DISTINCT
   stories.story_key,
   stories.story_title,
   pull_requests.pr_title,
   releases.release_title,
   CAST(julianday(pull_requests.pr_close) - julianday(releases.release_date)
+  -- days_open uses an exclusive convention: 0 means the PR closed on the
+  -- release day itself; NULL means the PR is still open (no close date).
   AS INTEGER)
     AS days_open,
   releases.release_date,
@@ -19,7 +23,12 @@ FROM
   JOIN pull_requests
     ON stories_pull_requests.pr_id = pull_requests.id
 WHERE
-  julianday(pull_requests.pr_close) > julianday(releases.release_date)
+  -- Flag PRs that closed on the release day, after it, or were never closed.
+  -- A PR must close at least 1 day before the release to be considered clean.
+  (
+    julianday(pull_requests.pr_close) >= julianday(releases.release_date)
+    OR pull_requests.pr_close IS NULL
+  )
   AND julianday('now') - julianday(releases.release_date) <= 60
 ORDER BY
   releases.release_date,

--- a/dora_lead_time/outlier_reports/E_counts_of_stories_without_pull_requests.sql
+++ b/dora_lead_time/outlier_reports/E_counts_of_stories_without_pull_requests.sql
@@ -1,13 +1,23 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 WITH project_story_counts AS (
   SELECT
     projects.project_key,
-    MIN(COUNT(stories.id), COUNT(CASE WHEN pull_requests.id IS NOT NULL THEN 1 END))
+    COUNT(DISTINCT stories.id)
+      AS total_stories,
+    COUNT(DISTINCT
+      CASE WHEN pull_requests.id IS NOT NULL
+        THEN stories.id
+      END
+    )
       AS stories_with_prs,
-    MIN(COUNT(stories.id), COUNT(CASE WHEN pull_requests.id IS NULL THEN 1 END))
-      AS stories_without_prs,
-    COUNT(stories.id)
-          AS total_stories
+    COUNT(DISTINCT
+      CASE WHEN pull_requests.id IS NULL
+        THEN stories.id
+      END
+    )
+      AS stories_without_prs
   FROM
     projects
     LEFT JOIN releases
@@ -23,7 +33,7 @@ WITH project_story_counts AS (
   GROUP BY
     projects.project_key
   HAVING
-    COUNT(stories.id) > 0
+    COUNT(DISTINCT stories.id) > 0
 )
 SELECT
   p.project_key,
@@ -33,8 +43,15 @@ SELECT
   COALESCE(s.total_stories, 0)
       AS total_stories,
   CASE
-    WHEN COALESCE(s.total_stories, 0) = 0 THEN 0.0
-    ELSE CAST(ROUND((COALESCE(s.stories_without_prs, 0) * 100.0 / COALESCE(s.total_stories, 0)), 0) AS INTEGER)
+    WHEN COALESCE(s.total_stories, 0) = 0
+      THEN 0.0
+      ELSE CAST(
+        ROUND(
+        (
+          COALESCE(s.stories_without_prs, 0) * 100.0 /
+          COALESCE(s.total_stories, 0)
+        ), 0)
+        AS INTEGER)
   END
       AS percentage_stories_without_prs
 FROM

--- a/dora_lead_time/outlier_reports/E_stories_without_pull_requests.sql
+++ b/dora_lead_time/outlier_reports/E_stories_without_pull_requests.sql
@@ -1,4 +1,6 @@
 -- database: ../../releases.2024-07.2025-03.db
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 SELECT DISTINCT
   stories.id AS story_id,
   projects.project_key,

--- a/dora_lead_time/outlier_reports/F_pull_requests_with_old_commits.sql
+++ b/dora_lead_time/outlier_reports/F_pull_requests_with_old_commits.sql
@@ -1,3 +1,5 @@
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 SELECT
   stories.story_key,
   stories.story_title,
@@ -18,6 +20,8 @@ FROM
     ON releases.project_id = projects.id
 WHERE
   pull_requests.earliest_commit_date IS NOT NULL
+  -- >5: flag PRs whose commits predate PR creation by more than 5 days,
+  -- indicating a long-lived branch that increases integration risk.
   AND julianday(pull_requests.pr_open) - julianday(pull_requests.earliest_commit_date) > 5
   AND julianday('now') - julianday(releases.release_date) <= 60
 ORDER BY

--- a/dora_lead_time/outlier_reports/G_zero_or_negative_lead_times.sql
+++ b/dora_lead_time/outlier_reports/G_zero_or_negative_lead_times.sql
@@ -1,3 +1,5 @@
+-- Lookback window: 60 days — a two-month rolling window captures recently
+-- closed releases and their associated stories and pull requests.
 SELECT
   stories.story_key,
   stories.story_title,
@@ -6,7 +8,7 @@ SELECT
   pull_requests.earliest_commit_date,
   pull_requests.pr_open AS pr_created_date,
   pull_requests.pr_close AS pr_closed_date,
-  julianday(releases.release_date) - julianday(pull_requests.earliest_commit_date) + 1
+  julianday(releases.release_date) - julianday(pull_requests.earliest_commit_date)
     AS lead_time,
   CASE
     WHEN pull_requests.earliest_commit_date > releases.release_date THEN 'Earliest commit after release'

--- a/dora_lead_time/schema/schema.sql
+++ b/dora_lead_time/schema/schema.sql
@@ -76,6 +76,9 @@ CREATE TABLE IF NOT EXISTS stories_pull_request_counts (
 DROP VIEW IF EXISTS lead_times;
 
 CREATE VIEW lead_times AS
+-- Stories without any associated pull request are excluded by design:
+-- lead time is measured via commits, so only stories linked to at least
+-- one PR contribute to the metric.
 SELECT
 	releases.id
 	AS release_id,
@@ -89,7 +92,7 @@ SELECT
 	pull_requests.pr_number,
 	pull_requests.earliest_commit_date,
 	julianday(releases.release_date) -
-	  julianday(pull_requests.earliest_commit_date) + 1
+	  julianday(pull_requests.earliest_commit_date)
 	  AS lead_time
 FROM
 	releases

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,254 @@
+"""Unit tests for api_client: exceptions, error-checking helpers, and api_get."""
+
+import time
+import pytest
+from unittest.mock import MagicMock, patch
+
+from dora_lead_time.api_client import (
+    ApiSource,
+    ApiError,
+    AuthError,
+    RateLimitError,
+    api_get,
+    raise_if_api_error,
+    raise_if_auth_error,
+    raise_if_rate_limit_error,
+)
+
+
+def _mock_response(status_code, headers=None):
+    """Build a minimal mock HTTP response."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    return response
+
+
+# ---------------------------------------------------------------------------
+# raise_if_auth_error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_raise_if_auth_error_raises(status_code):
+    """401 and 403 responses raise AuthError."""
+    response = _mock_response(status_code)
+    with pytest.raises(AuthError):
+        raise_if_auth_error(response, ApiSource.GITHUB)
+
+
+def test_raise_if_auth_error_message_contains_description():
+    """AuthError message identifies the API source."""
+    response = _mock_response(401)
+    with pytest.raises(AuthError, match="GitHub"):
+        raise_if_auth_error(response, ApiSource.GITHUB)
+
+
+@pytest.mark.parametrize("status_code", [200, 404, 429, 500])
+def test_raise_if_auth_error_no_raise(status_code):
+    """Non-401/403 responses do not raise AuthError."""
+    response = _mock_response(status_code)
+    raise_if_auth_error(response, ApiSource.GITHUB)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# raise_if_rate_limit_error — basic behaviour
+# ---------------------------------------------------------------------------
+
+def test_raise_if_rate_limit_error_raises_on_429():
+    """429 response raises RateLimitError."""
+    response = _mock_response(429)
+    with pytest.raises(RateLimitError):
+        raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)
+
+
+def test_raise_if_rate_limit_error_message_contains_source():
+    """RateLimitError message identifies the API source."""
+    response = _mock_response(429)
+    with pytest.raises(RateLimitError, match="GitHub"):
+        raise_if_rate_limit_error(response, ApiSource.GITHUB)
+
+
+@pytest.mark.parametrize("status_code", [200, 401, 403, 404, 500])
+def test_raise_if_rate_limit_error_no_raise(status_code):
+    """Non-429 responses do not raise RateLimitError."""
+    response = _mock_response(status_code)
+    raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# raise_if_rate_limit_error — Retry-After header (seconds)
+# ---------------------------------------------------------------------------
+
+def test_raise_if_rate_limit_error_retry_after_in_message():
+    """Retry-After header value is reflected in the error message."""
+    response = _mock_response(429, headers={"Retry-After": "60"})
+    with pytest.raises(RateLimitError, match="60 seconds"):
+        raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)
+
+
+def test_raise_if_rate_limit_error_retry_after_timestamp_in_message():
+    """Retry-After header produces a UTC timestamp in the error message."""
+    response = _mock_response(429, headers={"Retry-After": "120"})
+    with pytest.raises(RateLimitError, match="UTC"):
+        raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)
+
+
+# ---------------------------------------------------------------------------
+# raise_if_rate_limit_error — x-ratelimit-reset header (Unix timestamp)
+# ---------------------------------------------------------------------------
+
+def test_raise_if_rate_limit_error_ratelimit_reset_in_message():
+    """x-ratelimit-reset header produces a UTC reset time in the error message."""
+    reset_ts = int(time.time()) + 300
+    response = _mock_response(
+        429, headers={"x-ratelimit-reset": str(reset_ts)}
+    )
+    with pytest.raises(RateLimitError, match="UTC"):
+        raise_if_rate_limit_error(response, ApiSource.GITHUB)
+
+
+def test_raise_if_rate_limit_error_no_headers_unknown():
+    """429 with no retry headers includes 'unknown' in the error message."""
+    response = _mock_response(429)
+    with pytest.raises(RateLimitError, match="unknown"):
+        raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)
+
+
+def test_raise_if_rate_limit_error_prefers_retry_after_over_reset():
+    """Retry-After takes precedence over x-ratelimit-reset when both present."""
+    reset_ts = int(time.time()) + 300
+    response = _mock_response(
+        429,
+        headers={
+            "Retry-After": "30",
+            "x-ratelimit-reset": str(reset_ts),
+        },
+    )
+    with pytest.raises(RateLimitError, match="30 seconds"):
+        raise_if_rate_limit_error(response, ApiSource.ATLASSIAN)
+
+
+# ---------------------------------------------------------------------------
+# raise_if_api_error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("status_code", [400, 404, 500, 503])
+def test_raise_if_api_error_raises(status_code):
+    """4xx and 5xx responses raise ApiError."""
+    response = _mock_response(status_code)
+    with pytest.raises(ApiError):
+        raise_if_api_error(response, ApiSource.ATLASSIAN)
+
+
+def test_raise_if_api_error_message_contains_source():
+    """ApiError message identifies the API source."""
+    response = _mock_response(500)
+    with pytest.raises(ApiError, match="Atlassian"):
+        raise_if_api_error(response, ApiSource.ATLASSIAN)
+
+
+def test_raise_if_api_error_message_contains_status():
+    """ApiError message includes the HTTP status code."""
+    response = _mock_response(500)
+    with pytest.raises(ApiError, match="500"):
+        raise_if_api_error(response, ApiSource.ATLASSIAN)
+
+
+@pytest.mark.parametrize("status_code", [200, 201, 204])
+def test_raise_if_api_error_no_raise(status_code):
+    """2xx responses do not raise ApiError."""
+    response = _mock_response(status_code)
+    raise_if_api_error(response, ApiSource.GITHUB)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# api_get
+# ---------------------------------------------------------------------------
+
+def _patched_get(mock_response):
+    """Return a context manager that patches requests.get with mock_response."""
+    return patch("dora_lead_time.api_client.requests.get", return_value=mock_response)
+
+
+def test_api_get_200_returns_response():
+    """200 response is returned when raise_on_error is True (default)."""
+    mock = _mock_response(200)
+    with _patched_get(mock):
+        result = api_get("https://example.com", ApiSource.GITHUB, {})
+    assert result is mock
+
+
+def test_api_get_200_raise_on_error_false_returns_response():
+    """200 response is returned when raise_on_error is False."""
+    mock = _mock_response(200)
+    with _patched_get(mock):
+        result = api_get(
+            "https://example.com", ApiSource.GITHUB, {}, raise_on_error=False
+        )
+    assert result is mock
+
+
+def test_api_get_401_raises_auth_error():
+    """401 response raises AuthError regardless of raise_on_error."""
+    mock = _mock_response(401)
+    with _patched_get(mock):
+        with pytest.raises(AuthError):
+            api_get("https://example.com", ApiSource.GITHUB, {})
+
+
+def test_api_get_401_raise_on_error_false_raises_auth_error():
+    """401 response raises AuthError even when raise_on_error is False."""
+    mock = _mock_response(401)
+    with _patched_get(mock):
+        with pytest.raises(AuthError):
+            api_get(
+                "https://example.com", ApiSource.GITHUB, {}, raise_on_error=False
+            )
+
+
+def test_api_get_429_raises_rate_limit_error():
+    """429 response raises RateLimitError regardless of raise_on_error."""
+    mock = _mock_response(429)
+    with _patched_get(mock):
+        with pytest.raises(RateLimitError):
+            api_get("https://example.com", ApiSource.GITHUB, {})
+
+
+def test_api_get_500_raise_on_error_true_raises_api_error():
+    """500 response raises ApiError when raise_on_error is True (default)."""
+    mock = _mock_response(500)
+    with _patched_get(mock):
+        with pytest.raises(ApiError):
+            api_get("https://example.com", ApiSource.ATLASSIAN, {})
+
+
+def test_api_get_500_raise_on_error_false_returns_response():
+    """500 response is returned (not raised) when raise_on_error is False."""
+    mock = _mock_response(500)
+    with _patched_get(mock):
+        result = api_get(
+            "https://example.com", ApiSource.ATLASSIAN, {}, raise_on_error=False
+        )
+    assert result is mock
+    assert result.status_code == 500
+
+
+def test_api_get_passes_arguments_to_requests():
+    """All parameters are forwarded correctly to requests.get."""
+    mock = _mock_response(200)
+    with patch(
+        "dora_lead_time.api_client.requests.get", return_value=mock
+    ) as mock_get:
+        api_get(
+            "https://example.com",
+            ApiSource.GITHUB,
+            {"Authorization": "token abc"},
+            timeout=10,
+        )
+    mock_get.assert_called_once_with(
+        "https://example.com",
+        headers={"Authorization": "token abc"},
+        auth=None,
+        params=None,
+        timeout=10,
+    )

--- a/tests/test_atlassian_requests.py
+++ b/tests/test_atlassian_requests.py
@@ -8,16 +8,18 @@ from datetime import date, datetime
 from unittest.mock import patch, MagicMock
 
 from dora_lead_time.atlassian_requests import AtlassianRequests
+from dora_lead_time.api_client import ApiError, AuthError, RateLimitError
 from dora_lead_time.models import Project, Release, PullRequestIdentifier
 
 
 class MockResponse:
     """Mock response for requests."""
 
-    def __init__(self, json_data, status_code=200):
+    def __init__(self, json_data, status_code=200, headers=None):
         self.json_data = json_data
         self.status_code = status_code
         self.text = json.dumps(json_data)
+        self.headers = headers or {}
 
     def json(self):
         """Return JSON data."""
@@ -131,6 +133,7 @@ def test_get_projects(mock_get, atlassian_client):
             "Content-Type": "application/json"
         },
         auth=("test@example.com", "test-token"),
+        params=None,
         timeout=30,
     )
 
@@ -355,3 +358,195 @@ def test_get_stories_validation():
     # Test with empty string items
     with pytest.raises(ValueError):
         client.get_stories(["valid", ""])
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_projects_auth_error(mock_get, status_code, atlassian_client):
+    """Test that 401/403 on get_projects raises AuthError."""
+    mock_get.return_value = MockResponse({}, status_code)
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_projects()
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_releases_auth_error(mock_get, status_code, atlassian_client):
+    """Test that 401/403 on the projects list in get_releases raises AuthError."""
+    mock_get.return_value = MockResponse({}, status_code)
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_releases(
+            start_date=__import__("datetime").date(2023, 1, 1),
+            end_date=__import__("datetime").date(2023, 12, 31),
+        )
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_releases_versions_auth_error(
+    mock_get, status_code, atlassian_client
+):
+    """Test that 401/403 on per-project versions in get_releases raises AuthError."""
+    mock_projects = [
+        {"id": "10000", "key": "TEST", "projectTypeKey": "software"},
+    ]
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if url.endswith("/project"):
+            return MockResponse(mock_projects)
+        return MockResponse({}, status_code)
+
+    mock_get.side_effect = side_effect
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_releases(
+            start_date=__import__("datetime").date(2023, 1, 1),
+            end_date=__import__("datetime").date(2023, 12, 31),
+        )
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_stories_auth_error(mock_get, status_code, atlassian_client):
+    """Test that 401/403 on get_stories raises AuthError."""
+    mock_get.return_value = MockResponse({}, status_code)
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_stories(["10000"])
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_story_pull_requests_issue_auth_error(
+    mock_get, status_code, atlassian_client
+):
+    """Test that 401/403 on issue lookup in get_story_pull_requests raises AuthError."""
+    mock_get.return_value = MockResponse({}, status_code)
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_story_pull_requests(["TEST-1"])
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_story_pull_requests_dev_auth_error(
+    mock_get, status_code, atlassian_client
+):
+    """Test that 401/403 on dev-status in get_story_pull_requests raises AuthError."""
+    mock_issue_response = {"id": "12345"}
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if "rest/api/3/issue" in url:
+            return MockResponse(mock_issue_response)
+        return MockResponse({}, status_code)
+
+    mock_get.side_effect = side_effect
+
+    with pytest.raises(AuthError):
+        atlassian_client.get_story_pull_requests(["TEST-1"])
+
+
+@patch("requests.get")
+def test_get_projects_rate_limit_error(mock_get, atlassian_client):
+    """Test that a 429 on get_projects raises RateLimitError."""
+    mock_get.return_value = MockResponse(
+        {}, 429, headers={"Retry-After": "60"}
+    )
+    with pytest.raises(RateLimitError):
+        atlassian_client.get_projects()
+
+
+@patch("requests.get")
+def test_get_stories_rate_limit_error(mock_get, atlassian_client):
+    """Test that a 429 on get_stories raises RateLimitError."""
+    mock_get.return_value = MockResponse({}, 429)
+    with pytest.raises(RateLimitError):
+        atlassian_client.get_stories(["10000"])
+
+
+@patch("requests.get")
+def test_get_story_pull_requests_issue_rate_limit_error(
+    mock_get, atlassian_client
+):
+    """Test that a 429 on issue lookup raises RateLimitError."""
+    mock_get.return_value = MockResponse({}, 429)
+    with pytest.raises(RateLimitError):
+        atlassian_client.get_story_pull_requests(["TEST-1"])
+
+
+@patch("requests.get")
+def test_get_story_pull_requests_dev_rate_limit_error(
+    mock_get, atlassian_client
+):
+    """Test that a 429 on dev-status raises RateLimitError."""
+    mock_issue_response = {"id": "12345"}
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if "rest/api/3/issue" in url:
+            return MockResponse(mock_issue_response)
+        return MockResponse({}, 429)
+
+    mock_get.side_effect = side_effect
+
+    with pytest.raises(RateLimitError):
+        atlassian_client.get_story_pull_requests(["TEST-1"])
+
+
+@pytest.mark.parametrize("status_code", [404, 500, 503])
+@patch("requests.get")
+def test_get_projects_api_error(mock_get, status_code, atlassian_client):
+    """Test that 4xx/5xx on get_projects raises ApiError."""
+    mock_get.return_value = MockResponse({}, status_code)
+    with pytest.raises(ApiError):
+        atlassian_client.get_projects()
+
+
+@pytest.mark.parametrize("status_code", [404, 500, 503])
+@patch("requests.get")
+def test_get_releases_structural_api_error(
+    mock_get, status_code, atlassian_client
+):
+    """Test that 4xx/5xx on the projects list in get_releases raises ApiError."""
+    mock_get.return_value = MockResponse({}, status_code)
+    with pytest.raises(ApiError):
+        atlassian_client.get_releases(
+            start_date=__import__("datetime").date(2023, 1, 1),
+            end_date=__import__("datetime").date(2023, 12, 31),
+        )
+
+
+@pytest.mark.parametrize("status_code", [404, 500, 503])
+@patch("requests.get")
+def test_get_stories_api_error(mock_get, status_code, atlassian_client):
+    """Test that 4xx/5xx on get_stories raises ApiError."""
+    mock_get.return_value = MockResponse({}, status_code)
+    with pytest.raises(ApiError):
+        atlassian_client.get_stories(["10000"])
+
+
+@patch("requests.get")
+def test_get_releases_versions_non_200_skips(mock_get, atlassian_client):
+    """Test that per-project versions errors are skipped, not raised."""
+    mock_projects = [
+        {"id": "10000", "key": "TEST", "projectTypeKey": "software"},
+    ]
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if url.endswith("/project"):
+            return MockResponse(mock_projects)
+        return MockResponse({}, 404)
+
+    mock_get.side_effect = side_effect
+
+    # Should return empty list, not raise
+    releases = atlassian_client.get_releases(
+        start_date=__import__("datetime").date(2023, 1, 1),
+        end_date=__import__("datetime").date(2023, 12, 31),
+    )
+    assert releases == []

--- a/tests/test_database_processor.py
+++ b/tests/test_database_processor.py
@@ -4,7 +4,7 @@ import os
 import pytest
 import sqlite3
 from datetime import date, datetime
-from dora_lead_time.database_processor import DatabaseProcessor
+from dora_lead_time.database_processor import DatabaseProcessor, DatabaseOperationError
 from dora_lead_time.models import Project, PullRequestIdentifier, PullRequest
 
 
@@ -191,3 +191,32 @@ def test_save_and_retrieve_pull_request_details(db_processor):
 
     assert result[0] == "Test PR"
     assert result[1] == 3
+
+
+def test_save_projects_raises_on_missing_schema(db_processor):
+    """Test that save_projects raises DatabaseOperationError without schema."""
+    conn = sqlite3.connect(db_processor.sqlite_path)
+    conn.close()
+
+    projects = [Project(None, "P1", "PROJ1", "Project 1", "software")]
+    with pytest.raises(DatabaseOperationError):
+        db_processor.save_projects(projects)
+
+
+def test_retrieve_all_projects_raises_on_missing_table(db_processor):
+    """Test that retrieve_all_projects raises DatabaseOperationError without schema."""
+    conn = sqlite3.connect(db_processor.sqlite_path)
+    conn.close()
+
+    with pytest.raises(DatabaseOperationError):
+        db_processor.retrieve_all_projects()
+
+
+def test_save_releases_raises_on_missing_schema(db_processor):
+    """Test that save_releases raises DatabaseOperationError without schema."""
+    conn = sqlite3.connect(db_processor.sqlite_path)
+    conn.close()
+
+    releases = [(None, "REL-1", "Release 1", "desc", "2024-01-01", "PROJ1")]
+    with pytest.raises(DatabaseOperationError):
+        db_processor.save_releases(releases)

--- a/tests/test_github_requests.py
+++ b/tests/test_github_requests.py
@@ -8,16 +8,18 @@ from datetime import date, datetime
 from unittest.mock import patch, MagicMock
 
 from dora_lead_time.github_requests import GitHubRequests
+from dora_lead_time.api_client import AuthError, RateLimitError
 from dora_lead_time.models import PullRequestIdentifier, PullRequest
 
 
 class MockResponse:
     """Mock response for requests."""
 
-    def __init__(self, json_data, status_code=200):
+    def __init__(self, json_data, status_code=200, headers=None):
         self.json_data = json_data
         self.status_code = status_code
         self.text = json.dumps(json_data)
+        self.headers = headers or {}
 
     def json(self):
         """Return JSON data."""
@@ -132,11 +134,9 @@ def test_get_pull_request_details(mock_get, github_client):
 
 @patch("requests.get")
 def test_get_pull_request_details_api_error(mock_get, github_client):
-    """Test handling API errors when getting pull request details."""
-    # Mock failed API response
+    """Test that non-auth HTTP errors on PR details skip the PR gracefully."""
     mock_get.return_value = MockResponse({}, 404)
 
-    # Test data
     pull_requests = [
         PullRequestIdentifier(
             id=1,
@@ -146,35 +146,29 @@ def test_get_pull_request_details_api_error(mock_get, github_client):
         )
     ]
 
-    # Call the method
     result = github_client.get_pull_request_details(pull_requests)
 
-    # Should return empty list
+    # Single-item failure is skipped; result is empty
     assert len(result) == 0
 
 
 @patch("requests.get")
 def test_get_pull_request_details_commits_error(mock_get, github_client):
-    """Test handling errors when getting commit details."""
-    # Mock PR data success but commits failure
+    """Test that HTTP errors on the commits endpoint yield empty commit data."""
     mock_pr_data = {
         "title": "Test PR",
         "created_at": "2023-01-01T10:00:00Z",
         "closed_at": "2023-01-02T15:30:00Z",
     }
 
-    # Configure the mock to return success for PR but fail for commits
     def side_effect(*args, **kwargs):
         url = args[0]
         if "pulls/123" in url and "/commits" not in url:
             return MockResponse(mock_pr_data)
-        elif "pulls/123/commits" in url:
-            return MockResponse({}, 404)
         return MockResponse({}, 404)
 
     mock_get.side_effect = side_effect
 
-    # Test data
     pull_requests = [
         PullRequestIdentifier(
             id=1,
@@ -184,10 +178,9 @@ def test_get_pull_request_details_commits_error(mock_get, github_client):
         )
     ]
 
-    # Call the method
     result = github_client.get_pull_request_details(pull_requests)
 
-    # Should still return the PR but with empty commit data
+    # PR is still recorded, but with empty commit data
     assert len(result) == 1
     pr = result[0]
     assert pr.commit_count == 0
@@ -238,3 +231,107 @@ def test_get_pull_request_details_missing_token_for_org(mock_get, github_client)
     # Should return empty list since org has no token
     assert len(result) == 0
     assert mock_get.call_count == 0  # No API calls made
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_pull_request_details_auth_error(
+    mock_get, status_code, github_client
+):
+    """Test that 401/403 responses raise AuthError."""
+    mock_get.return_value = MockResponse({}, status_code)
+
+    pull_requests = [
+        PullRequestIdentifier(
+            id=1,
+            pr_owner="Org1",
+            pr_repository="test-repo",
+            pr_number="123"
+        )
+    ]
+
+    with pytest.raises(AuthError):
+        github_client.get_pull_request_details(pull_requests)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+@patch("requests.get")
+def test_get_pull_request_commits_auth_error(
+    mock_get, status_code, github_client
+):
+    """Test that 401/403 on commits endpoint raises AuthError."""
+    mock_pr_data = {
+        "title": "Test PR",
+        "created_at": "2023-01-01T10:00:00Z",
+        "closed_at": "2023-01-02T15:30:00Z",
+    }
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if "pulls/123" in url and "/commits" not in url:
+            return MockResponse(mock_pr_data)
+        return MockResponse({}, status_code)
+
+    mock_get.side_effect = side_effect
+
+    pull_requests = [
+        PullRequestIdentifier(
+            id=1,
+            pr_owner="Org1",
+            pr_repository="test-repo",
+            pr_number="123"
+        )
+    ]
+
+    with pytest.raises(AuthError):
+        github_client.get_pull_request_details(pull_requests)
+
+
+@patch("requests.get")
+def test_get_pull_request_details_rate_limit_error(mock_get, github_client):
+    """Test that a 429 response on PR details raises RateLimitError."""
+    mock_get.return_value = MockResponse(
+        {}, 429, headers={"x-ratelimit-reset": "9999999999"}
+    )
+
+    pull_requests = [
+        PullRequestIdentifier(
+            id=1,
+            pr_owner="Org1",
+            pr_repository="test-repo",
+            pr_number="123"
+        )
+    ]
+
+    with pytest.raises(RateLimitError):
+        github_client.get_pull_request_details(pull_requests)
+
+
+@patch("requests.get")
+def test_get_pull_request_commits_rate_limit_error(mock_get, github_client):
+    """Test that a 429 on the commits endpoint raises RateLimitError."""
+    mock_pr_data = {
+        "title": "Test PR",
+        "created_at": "2023-01-01T10:00:00Z",
+        "closed_at": "2023-01-02T15:30:00Z",
+    }
+
+    def side_effect(*args, **kwargs):
+        url = args[0]
+        if "pulls/123" in url and "/commits" not in url:
+            return MockResponse(mock_pr_data)
+        return MockResponse({}, 429, headers={"Retry-After": "30"})
+
+    mock_get.side_effect = side_effect
+
+    pull_requests = [
+        PullRequestIdentifier(
+            id=1,
+            pr_owner="Org1",
+            pr_repository="test-repo",
+            pr_number="123"
+        )
+    ]
+
+    with pytest.raises(RateLimitError):
+        github_client.get_pull_request_details(pull_requests)


### PR DESCRIPTION
## Summary
This PR hardens the lead-time metric pipeline by tightening request/database handling and broadening automated test coverage.

### What changed
- Strengthened core API client behavior in `dora_lead_time/api_client.py`
- Hardened request handling paths in Atlassian and GitHub integrations
- Improved database processing and related schema/outlier SQL support
- Updated reporting/entrypoint wiring where needed for robustness
- Added and expanded tests across API client, Atlassian requests, database processing, and GitHub requests
- Added implementation/design notes documenting the hardening work

## Files of note
- `dora_lead_time/api_client.py`
- `dora_lead_time/atlassian_requests.py`
- `dora_lead_time/database_processor.py`
- `dora_lead_time/github_requests.py`
- `dora_lead_time/lead_time_report.py`
- `dora_lead_time/main.py`
- `dora_lead_time/schema/schema.sql`
- `dora_lead_time/outlier_reports/*.sql`
- `tests/test_api_client.py`
- `tests/test_atlassian_requests.py`
- `tests/test_database_processor.py`
- `tests/test_github_requests.py`

## Validation
- `poetry run pytest`
